### PR TITLE
fix has_unstable check in comment templates

### DIFF
--- a/wptdash/commenter.py
+++ b/wptdash/commenter.py
@@ -4,6 +4,7 @@
 import configparser
 import logging
 import requests
+from operator import attrgetter
 from flask import render_template
 
 from wptdash.github import GitHub
@@ -19,13 +20,26 @@ REPO_NAME = CONFIG.get('GitHub', 'REPO')
 def update_github_comment(pr):
     if pr.builds:
         github = GitHub()
-        comment = render_template('comment.md', pull=pr, app_domain=APP_DOMAIN,
-                                  org_name=ORG_NAME, repo_name=REPO_NAME)
+        build = sorted(pr.builds, key=attrgetter('started_at'), reverse=True)[0]
+        has_unstable = False
+        for job in build.jobs:
+            for test in job.tests:
+                if not test.consistent:
+                    has_unstable = True
+                    break
+            if has_unstable:
+                break
+
+        comment = render_template('comment.md', build=build,
+                                  app_domain=APP_DOMAIN, org_name=ORG_NAME,
+                                  repo_name=REPO_NAME,
+                                  has_unstable=has_unstable)
         if not github.validate_comment_length(comment):
-            comment = render_template('comment-short.md', pull=pr,
+            comment = render_template('comment-short.md', build=build,
                                       app_domain=APP_DOMAIN, org_name=ORG_NAME,
                                       characters=github.max_comment_length,
-                                      repo_name=REPO_NAME)
+                                      repo_name=REPO_NAME,
+                                      has_unstable=has_unstable)
         try:
             github.post_comment(pr.number, comment)
         except requests.RequestException as err:

--- a/wptdash/templates/comment-short.md
+++ b/wptdash/templates/comment-short.md
@@ -1,6 +1,3 @@
-{% set build = pull.builds|sort(attribute='number', reverse=True)|first %}
-{% set has_unstable = build.jobs|map(attribute='tests')|map('selectattr', 'consistent', 'sameas', false)|list|length %}
-
 # Build {{ build.status.name }}
 
 Started: {{ build.started_at }}

--- a/wptdash/templates/comment.md
+++ b/wptdash/templates/comment.md
@@ -1,6 +1,3 @@
-{% set build = pull.builds|sort(attribute='number', reverse=True)|first %}
-{% set has_unstable = build.jobs|map(attribute='tests')|map('selectattr', 'consistent', 'sameas', false)|list|length %}
-
 # Build {{ build.status.name }}
 
 Started: {{ build.started_at }}

--- a/wptdash/templates/pull.html
+++ b/wptdash/templates/pull.html
@@ -106,7 +106,7 @@
             </tr>
           </thead>
           <tbody>
-            {% for build in pull.builds %}
+            {% for build in pull.builds|sort(attribute='started_at', reverse=True) %}
               <tr class="{{build_status_classes[build.status.name]}}">
                 <td><a href="{{ url_for('routes.build_detail', build_number=build.number) }}">{{ build.number }}</a></td>
                 <td>{{ build.status.name }}</td>


### PR DESCRIPTION
This fixes the issue where `has_unstable` always returned true. Verified it works for both passing and failing jobs now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptdash/11)
<!-- Reviewable:end -->
