### PR TITLE
add letsencrypt ssl to ansible configuration

### DIFF
--- a/ansible/configure.yml
+++ b/ansible/configure.yml
@@ -13,8 +13,8 @@
     - {role: nginx, tags: nginx}
     - {role: uwsgi, tags: uwsgi}
   handlers:
-    - name: restart nginx
-      service: name=nginx state=restarted
+    - name: reload nginx
+      service: name=nginx state=reloaded
     - name: restart sshd
       service: name=ssh state=restarted
     - name: restart uwsgi

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -70,13 +70,16 @@ pip3_packages:
 ############
 
 # Should the nginx server use HTTPS instead of HTTP?
-ssl: false
+ssl: true
 
 # If ssl is enabled, these cert/key files will be used by nginx. You will need
 # to ensure these files are valid and already on the server (which you can do
 # via cloud-init, scp, etc).
-ssl_cert_path: /etc/ssl/star.{{project_name}}.com.cert
-ssl_key_path: /etc/ssl/star.{{project_name}}.com.key
+ssl_cert_path: /etc/ssl/cert.pem
+ssl_key_path: /etc/ssl/privkey.pem
+
+# If ssl is enabled, email address to receive notifications from letsencrypt.
+letsencrypt_email: infrastructure@bocoup.com
 
 # Use a custom parameter for stronger DHE key exchange.
 dhe_param_path: /etc/ssl/certs/dhparam.pem

--- a/ansible/roles/nginx/tasks/certbot.yml
+++ b/ansible/roles/nginx/tasks/certbot.yml
@@ -1,0 +1,52 @@
+# Use certbot to generate letsencrypt ssl certs. This will also set up a cron
+# job that will ensure the certs are kept up-to-date.
+
+- name: add certbot ppa to apt
+  apt_repository:
+    repo: "ppa:certbot/certbot"
+
+- name: install certbot
+  apt:
+    name: certbot=0.14.*
+    state: present
+
+- name: ensure certbot well-known path exists
+  file:
+    path: "{{base_path}}/certbot/.well-known"
+    state: directory
+
+- name: test if certbot has been initialized
+  stat:
+    path: /etc/letsencrypt/live/{{site_fqdn}}/fullchain.pem
+  register: cert_file
+
+- name: ensure any pending nginx reload happens immediately
+  meta: flush_handlers
+  when: cert_file.stat.exists == false
+
+- name: intialize certbot
+  command: >
+    certbot certonly --webroot --agree-tos --non-interactive
+    {{ (env == 'production') | ternary('', '--test-cert') }}
+    --email {{letsencrypt_email}}
+    -w {{base_path}}/certbot
+    -d {{site_fqdn}}
+  when: cert_file.stat.exists == false
+
+- name: ensure certbot certs are linked
+  file:
+    src: '/etc/letsencrypt/live/{{site_fqdn}}/{{item.src}}'
+    dest: '{{item.dest}}'
+    state: link
+    force: true
+  with_items:
+    - { src: 'fullchain.pem', dest: '{{ssl_cert_path}}' }
+    - { src: 'privkey.pem', dest: '{{ssl_key_path}}' }
+  notify: reload nginx
+
+- name: Add cron job for cert renewal
+  cron:
+    name: Certbot automatic renewal.
+    job: "/usr/bin/certbot renew --quiet --no-self-upgrade && service nginx reload"
+    minute: 0
+    hour: 23

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -64,3 +64,6 @@
 
 - fail: msg="nginx config is invalid"
   when: nginx_test_valid | failed
+
+- include: certbot.yml
+  when: ssl and inventory_hostname != 'vagrant'

--- a/ansible/roles/nginx/tasks/ssl.yml
+++ b/ansible/roles/nginx/tasks/ssl.yml
@@ -5,17 +5,16 @@
   shell: openssl dhparam -dsaparam -out {{dhe_param_path}} 4096
   args:
     creates: "{{dhe_param_path}}"
-  notify: restart nginx
+  notify: reload nginx
 
-- name: create self-signed ssl cert/key - development only!
+- name: create self-signed ssl cert/key
   command: >
     openssl req -new -nodes -x509
     -subj "/C=US/ST=Oregon/L=Portland/O=IT/CN={{site_fqdn}}" -days 3650
     -keyout {{ssl_key_path}} -out {{ssl_cert_path}} -extensions v3_ca
   args:
     creates: "{{ssl_cert_path}}"
-  when: env == "development"
-  notify: restart nginx
+  notify: reload nginx
 
 - name: ensure ssl cert/key exist
   stat: path={{item}}

--- a/ansible/roles/nginx/templates/site.conf.j2
+++ b/ansible/roles/nginx/templates/site.conf.j2
@@ -1,5 +1,10 @@
 server {
+{% if ssl %}
+  listen 443 ssl;
+  include ssl_params;
+{% else %}
   listen 80;
+{% endif %}
   include gzip_params;
 
   server_name {{site_fqdn}};
@@ -12,8 +17,31 @@ server {
   location = /robots.txt { access_log off; log_not_found off; }
   location = /favicon.ico { access_log off; log_not_found off; }
 
+{% if ssl and inventory_hostname != 'vagrant' %}
+  # This allows certbot to get letsencrypt certs.
+  location /.well-known {
+    alias {{base_path}}/certbot/.well-known;
+  }
+{% endif %}
+
   location / {
     include uwsgi_params;
     uwsgi_pass unix:/tmp/{{project_name}}.sock;
   }
+}
+
+{% if ssl %}
+# Force HTTPS for all connections.
+server {
+  listen 80;
+  server_name {{site_fqdn}};
+  return 301 https://$server_name$request_uri;
+}
+{% endif %}
+
+# Catchall, force unknown domains to redirect to site_fqdn.
+server {
+  listen 80 default_server;
+  server_name _;
+  return 301 $scheme://{{site_fqdn}}$request_uri;
 }


### PR DESCRIPTION
This moves pulls and pulls-staging.web-platform-tests.org to SSL via free self-renewing certificates from [letsencrypt](https://letsencrypt.org/). You can see this in effect on the staging server: https://pulls-staging.web-platform-tests.org/.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptdash/12)
<!-- Reviewable:end -->
