### PR TITLE
add list of failing jobs to PR comment

### DIFF
--- a/wptdash/templates/comment-short.md
+++ b/wptdash/templates/comment-short.md
@@ -5,6 +5,14 @@ Finished: {{ build.finished_at }}
 
 > This report has been truncated because the number of unstable tests exceeds GitHub.com's character limit for comments ({{characters}} characters).
 
+{% if failing_jobs|length %}
+<h2>Failing Jobs</h2>
+<ul>
+{% for job_name in failing_jobs %}
+<li>{{ job_name }}</li>
+{% endfor %}
+</ul>
+{% endif %}
 
 {% if has_unstable %}
 <h2>Unstable Browsers</h2>

--- a/wptdash/templates/comment.md
+++ b/wptdash/templates/comment.md
@@ -3,6 +3,15 @@
 Started: {{ build.started_at }}
 Finished: {{ build.finished_at }}
 
+{% if failing_jobs|length %}
+<h2>Failing Jobs</h2>
+<ul>
+{% for job_name in failing_jobs %}
+<li>{{ job_name }}</li>
+{% endfor %}
+</ul>
+{% endif %}
+
 {% if has_unstable %}
 <h2>Unstable Results</h2>
   {% for job in build.jobs|sort(attribute='id') %}


### PR DESCRIPTION
Now that we have all of the jobs in the DB, we can show failing ones in the comment. It looks like [this](https://github.com/bobholt/web-platform-tests/pull/23#issuecomment-321319826).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptdash/17)
<!-- Reviewable:end -->
