### PR TITLE
remove locked certbot version

### DIFF
--- a/ansible/roles/nginx/tasks/certbot.yml
+++ b/ansible/roles/nginx/tasks/certbot.yml
@@ -7,7 +7,7 @@
 
 - name: install certbot
   apt:
-    name: certbot=0.14.*
+    name: certbot
     state: present
 
 - name: ensure certbot well-known path exists


### PR DESCRIPTION
It turns out EFF removes old versions of certbot from their PPA (likely for good reason), so we can't version-lock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptdash/18)
<!-- Reviewable:end -->
