### PR TITLE
fix base path ownership nearer usage

### DIFF
--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -2,14 +2,6 @@
 # or the project is cloned or built. All system dependencies should be
 # installed here.
 
-- name: ensure base path exists and belongs to www-data
-  file:
-    path: "{{base_path }}"
-    state: directory
-    group: www-data
-    owner: www-data
-    recurse: yes
-
 - name: Update apt/aptitude
   apt:
     name: aptitude

--- a/ansible/roles/deploy/tasks/main.yml
+++ b/ansible/roles/deploy/tasks/main.yml
@@ -3,6 +3,14 @@
 # build regardless of prior status. When done, symlink the specified commit
 # to make it go live, and remove old clones to free up disk space.
 
+- name: ensure base path exists and belongs to www-data
+  file:
+    path: "{{base_path }}"
+    state: directory
+    group: www-data
+    owner: www-data
+    recurse: yes
+
 - name: check if specified commit has already been deployed
   stat: path={{base_path}}/{{commit}} get_checksum=no get_md5=no
   register: commit_dir


### PR DESCRIPTION
we don't need the base path in provisioning - only in configure/deploy.
move setting up base path to deploy role (which is invoked by configure).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-pullresults/35)
<!-- Reviewable:end -->
