### PR TITLE
Include 'received' as possible state

### DIFF
--- a/wptdash/blueprints/routes.py
+++ b/wptdash/blueprints/routes.py
@@ -180,7 +180,8 @@ def add_build():
                         'state': {
                             'type': 'string',
                             'enum': ['received', 'created', 'queued', 'started',
-                                     'passed', 'failed', 'errored', 'finished']
+                                     'passed', 'failed', 'errored', 'canceled',
+                                     'finished']
                         },
                         'started_at': {'oneOf': [
                             {'$ref': '#/definitions/date_time'},
@@ -344,7 +345,8 @@ def add_stability_check():
                     'status': {
                         'type': 'string',
                         'enum': ['received', 'created', 'queued', 'started',
-                                 'passed', 'failed', 'errored', 'finished']
+                                 'passed', 'failed', 'errored', 'canceled',
+                                 'finished']
                     },
                 },
                 'required': [

--- a/wptdash/blueprints/routes.py
+++ b/wptdash/blueprints/routes.py
@@ -179,8 +179,8 @@ def add_build():
                         'number': {'type': 'string'},
                         'state': {
                             'type': 'string',
-                            'enum': ['created', 'queued', 'started', 'passed',
-                                     'failed', 'errored', 'finished']
+                            'enum': ['received', 'created', 'queued', 'started',
+                                     'passed', 'failed', 'errored', 'finished']
                         },
                         'started_at': {'oneOf': [
                             {'$ref': '#/definitions/date_time'},
@@ -343,8 +343,8 @@ def add_stability_check():
                     'allow_failure': {'type': 'boolean'},
                     'status': {
                         'type': 'string',
-                        'enum': ['created', 'queued', 'started', 'passed',
-                                 'failed', 'errored', 'finished']
+                        'enum': ['received', 'created', 'queued', 'started',
+                                 'passed', 'failed', 'errored', 'finished']
                     },
                 },
                 'required': [


### PR DESCRIPTION
We're getting some major log noise from the first setup state 'received'.

e.g. 

    [2017-12-20 16:10:37,869] ERROR in app: Exception on /api/build [POST]
    Traceback (most recent call last):
      File "/var/www/wpt-pullresults/venv/lib/python3.5/site-packages/flask/app.py", line 1982, in wsgi_app
        response = self.full_dispatch_request()
      File "/var/www/wpt-pullresults/venv/lib/python3.5/site-packages/flask/app.py", line 1614, in full_dispatch_request
        rv = self.handle_user_exception(e)
      File "/var/www/wpt-pullresults/venv/lib/python3.5/site-packages/flask/app.py", line 1517, in handle_user_exception
        reraise(exc_type, exc_value, tb)
      File "/var/www/wpt-pullresults/venv/lib/python3.5/site-packages/flask/_compat.py", line 33, in reraise
        raise value
      File "/var/www/wpt-pullresults/venv/lib/python3.5/site-packages/flask/app.py", line 1612, in full_dispatch_request
        rv = self.dispatch_request()
      File "/var/www/wpt-pullresults/venv/lib/python3.5/site-packages/flask/app.py", line 1598, in dispatch_request
        return self.view_functions[rule.endpoint](**req.view_args)
      File "./wptdash/blueprints/routes.py", line 183, in add_build
        resp = validate(json.loads(request.form['payload']), schema)
      File "/var/www/wpt-pullresults/venv/lib/python3.5/site-packages/jsonschema/validators.py", line 541, in validate
        cls(schema, *args, **kwargs).validate(instance)
      File "/var/www/wpt-pullresults/venv/lib/python3.5/site-packages/jsonschema/validators.py", line 130, in validate
        raise error
    jsonschema.exceptions.ValidationError: 'received' is not one of ['created', 'queued', 'started', 'passed', 'failed', 'errored', 'finished']

    Failed validating 'enum' in schema['properties']['matrix']['items']['properties']['state']:
        {'enum': ['created',
                  'queued',
                  'started',
                  'passed',
                  'failed',
                  'errored',
                  'finished'],
         'type': 'string'}

    On instance['matrix'][10]['state']:
        'received'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-pullresults/49)
<!-- Reviewable:end -->
