### PR TITLE
Serve results summary JSON at pulls/{id}/summary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,9 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,
     install_requires=[
-        'flask', 'flask-sqlalchemy', 'flask-migrate', 'flask-script',
-        'jsonschema', 'pyOpenSSL', 'requests', 'requests-cache',
+        'flask', 'flask-cors', 'flask-sqlalchemy', 'flask-migrate',
+        'flask-script', 'jsonschema', 'pyOpenSSL', 'requests',
+        'requests-cache',
     ],
     setup_requires=[
         'pytest-runner',

--- a/wptdash/blueprints/routes.py
+++ b/wptdash/blueprints/routes.py
@@ -8,10 +8,10 @@
     a single GitHub comment and provides an interface for displaying
     more detailed forms of that information.
 """
-from collections import defaultdict
 import configparser
 from datetime import datetime, timedelta
 from flask import Blueprint, g, render_template, request
+from flask_cors import cross_origin
 from jsonschema import validate
 import hashlib
 import hmac
@@ -76,6 +76,18 @@ def job_detail(job_number):
     job = models.get(db.session, models.Job, number=job_number)
     return render_template('job.html', job=job, job_number=job_number,
                            org_name=ORG, repo_name=REPO)
+
+
+@bp.route('/job/<string:job_number>/summary')
+@cross_origin()
+def job_summary(job_number):
+    db = g.db
+    models = g.models
+    job = models.get(db.session, models.Job, number=job_number)
+    summary = job.results_summary
+    if summary is None:
+        return '{}', 404
+    return json.dumps(summary)
 
 
 @bp.route('/performance')


### PR DESCRIPTION
Serves the JSON results-summary blob in the same format used by wpt.fyi, so that a diff (and any regressions) can be surfed through.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-pullresults/54)
<!-- Reviewable:end -->
