### PR TITLE
fix erroneous aliasing of python app to project name

### DIFF
--- a/ansible/roles/uwsgi/templates/uwsgi.ini.j2
+++ b/ansible/roles/uwsgi/templates/uwsgi.ini.j2
@@ -5,7 +5,7 @@
 socket          = /tmp/{{project_name}}.sock
 chdir           = {{site_path}}
 master          = true
-module          = {{project_name}}.prodapp:prod_app
+module          = wptdash.prodapp:prod_app
 processes       = 1
 logger          = file:{{site_path}}/logs/uwsgi.log
 vacuum          = true


### PR DESCRIPTION
This seems to have been an accidental aliasing. Configuring the server with it causes uwsgi to not be able to find the flask app, which is still called wptdash in the project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-pullresults/55)
<!-- Reviewable:end -->
